### PR TITLE
fix: Employee 삭제 시 BinaryContent LAZY 로딩 문제를 fetch join으로 해결

### DIFF
--- a/hr_bank/src/main/java/com/codeit/hrbank/repository/EmployeeRepository.java
+++ b/hr_bank/src/main/java/com/codeit/hrbank/repository/EmployeeRepository.java
@@ -12,7 +12,10 @@ public interface EmployeeRepository extends JpaRepository<Employee, Long>, Emplo
 
   boolean existsByEmailAndIdNot(String email, Long id);
 
-  @Query("select e from Employee e join fetch e.department where e.id = :id")
-  Optional<Employee> findByIdWithDepartment(Long id);
+  @Query("select e from Employee e " +
+      "left join fetch e.department " +
+      "left join fetch e.binaryContent " +
+      "where e.id = :id")
+  Optional<Employee> findByIdWithRelations(Long id);
 }
 

--- a/hr_bank/src/main/java/com/codeit/hrbank/service/impl/EmployeeServiceImpl.java
+++ b/hr_bank/src/main/java/com/codeit/hrbank/service/impl/EmployeeServiceImpl.java
@@ -180,7 +180,7 @@ public class EmployeeServiceImpl implements EmployeeService {
   @Override
   @Transactional
   public Employee deleteEmployeeDoSaveLog(Long employeeId, String ipAddress){
-    Employee employee = employeeRepository.findByIdWithDepartment(employeeId)
+    Employee employee = employeeRepository.findByIdWithRelations(employeeId)
         .orElseThrow(() -> new NoSuchElementException("회원이 존재하지 않습니다."));
 
     ChangeLog changeLog = ChangeLogUtils.createChangeLog(ChangeLogType.DELETED, ipAddress, null, employee);


### PR DESCRIPTION
### 변경 사항
- 직원 삭제 시 ChangeLog, History 생성 과정에서 LazyInitializationException 방지
  - Employee 조회 시 Department, BinaryContent를 fetch join 으로 미리 로딩
